### PR TITLE
add image to main page, center text below image

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,30 +43,37 @@
 
     <div class="top-div">
       <div class="container pb-3">
-        <ul class="list-unstyled">
-          <li>
-            <i class="fas fa-map-marker-alt text-secondary"></i>
-            <a href="https://yandex.ru/maps/org/dve_pyatyorki/1024420856/?ll=20.509270%2C54.727694&oid=1024420856&ol=biz&z=18">
-              <span>
-                Калининград, улица Горького, 55
-              </span>
-            </a>
-          </li>
-          <li>
-            <span>
-              <i class="far fa-clock text-secondary" ></i>
-            </span>
-            с 09:00 до 19:00
-            <span id="text-open" class="text-success d-none">
-               (Сейчас открыто)
-            </span>
-          </li>
-        </ul>
+        <div class="row">
+          <div class="col-sm-6">
+            <ul class="list-unstyled">
+              <li>
+                <i class="fas fa-map-marker-alt text-secondary"></i>
+                <a href="https://yandex.ru/maps/org/dve_pyatyorki/1024420856/?ll=20.509270%2C54.727694&oid=1024420856&ol=biz&z=18">
+                  <span>
+                    Калининград, улица Горького, 55
+                  </span>
+                </a>
+              </li>
+              <li>
+                <span>
+                  <i class="far fa-clock text-secondary" ></i>
+                </span>
+                с 09:00 до 19:00
+                <span id="text-open" class="text-success d-none">
+                   (Сейчас открыто)
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div class="col-sm-6">
+            <img class="img-fluid" src="./assets/ readme/background.jpg" alt="Торговый центр «Две пятерки»" title="Торговый центр «Две пятерки»">
+          </div>
+        </div>
       </div>
     </div>
 
     <div class="container pb-3">
-      Добро пожаловать на сайт торгового центра «Две пятерки»
+      <p class="text-center">Добро пожаловать на сайт торгового центра «Две пятерки»</p>
     </div>
     <section class="container pt-3 pb-3">
       <p class="text-center">


### PR DESCRIPTION
This is the change required in #71 

- added image from assets/ readme/background.jpg to the right from the address
- center text below image added

![image](https://user-images.githubusercontent.com/5624598/66723909-c5223780-ee27-11e9-8f49-b1c313145489.png)
![image](https://user-images.githubusercontent.com/5624598/66723911-ce130900-ee27-11e9-8e92-77cd62a291f0.png)
